### PR TITLE
Feat: Implement Team Management with API Data and Reusable Modals

### DIFF
--- a/src/components/EditModal.jsx
+++ b/src/components/EditModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   Modal,
   Box,
@@ -19,7 +19,7 @@ import {
 import { Formik, Form, Field, ErrorMessage } from 'formik';
 import * as Yup from 'yup';
 import { useTheme } from '@mui/material/styles';
-import { tokens } from '../theme';
+import { tokens } from '../../theme';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -42,28 +42,23 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
 
   const [activeStep, setActiveStep] = useState(0);
 
-  const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
-  };
+
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  // Create a Yup validation schema based on the provided fields
   const validationSchema = Yup.object().shape(
     fields.reduce((schema, field) => {
       let validator;
+
       if (field.nestedFields) {
-        // Correctly create a nested object schema using Yup.object()
-        validator = Yup.object().shape( 
+        validator = Yup.object().shape(
           field.nestedFields.reduce((nestedSchema, nestedField) => {
-            let nestedValidator = Yup.string(); 
+            let nestedValidator = Yup.string();
 
             if (nestedField.required) {
-              nestedValidator = nestedValidator.required(
-                `${nestedField.label} is required`
-              );
+              nestedValidator = nestedValidator.required(`${nestedField.label} is required`);
             }
 
             return {
@@ -71,16 +66,15 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
               [nestedField.name]: nestedValidator,
             };
           }, {})
-        ); 
+        );
       } else if (field.type === 'email') {
         validator = Yup.string().email('Invalid email address');
       } else if (field.type === 'number') {
-        validator = Yup.number().typeError('Must be a number'); 
+        validator = Yup.number().typeError('Must be a number');
       } else if (field.type === 'date') {
-        validator = Yup.date().typeError('Invalid date'); 
+        validator = Yup.date().typeError('Invalid date');
       } else {
-        // Default to Yup.string() for other fields
-        validator = Yup.string();
+        validator = Yup.string(); 
       }
 
       if (field.required) {
@@ -92,18 +86,18 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
         [field.name]: validator,
       };
     }, {})
-  ); 
+  );
 
   const steps = [
     {
       label: 'Basic Information',
-      description: 'Update the team member\'s core details.',
-      fields: fields.filter((field) => !field.nestedFields), // Fields without nestedFields
+      description: "Update the team member's core details.",
+      fields: fields.filter((field) => !field.nestedFields),
     },
     {
       label: 'Next of Kin',
       description: 'Provide emergency contact information.',
-      fields: fields.filter((field) => field.name === 'nextOfKin'), // Only the 'nextOfKin' field
+      fields: fields.filter((field) => field.name === 'nextOfKin'), 
     },
   ];
 
@@ -119,20 +113,22 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
             <Step key={step.label}>
               <StepLabel>{step.label}</StepLabel>
               <StepContent>
-                <Typography>{step.description}</Typography> {/* Step Description */}
+                <Typography>{step.description}</Typography> 
 
-                {/* Form within the Step */}
                 <Formik
                   initialValues={initialValues}
-                  validationSchema={validationSchema}
-                  onSubmit={onSubmit}
+                  validationSchema={validationSchema} 
+                  onSubmit={(values) => { 
+                    onSubmit(values);
+                    setActiveStep(0); // Reset to the first step after submission 
+                  }}
                 >
                   {({ isSubmitting, values, setFieldValue, touched, errors }) => (
                     <Form>
                       <Grid container spacing={2} sx={{ marginTop: 2 }}>
                         {step.fields.map((field) => {
+                          // Handle nested fields
                           if (field.nestedFields) {
-                            // Render nested fields
                             return field.nestedFields.map((nestedField) => (
                               <Grid item xs={6} key={nestedField.name}>
                                 <Field
@@ -141,93 +137,54 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                                   name={`${field.name}.${nestedField.name}`}
                                   type={nestedField.type || 'text'}
                                   fullWidth
-                                  error={
-                                    touched[field.name]?.[
-                                      nestedField.name
-                                    ] &&
-                                    !!errors[field.name]?.[
-                                      nestedField.name
-                                    ]
-                                  }
-                                  helperText={
-                                    touched[field.name]?.[
-                                      nestedField.name
-                                    ] &&
-                                    errors[field.name]?.[
-                                      nestedField.name
-                                    ]
-                                  }
+                                  error={touched[field.name]?.[nestedField.name] && !!errors[field.name]?.[nestedField.name]}
+                                  helperText={touched[field.name]?.[nestedField.name] && errors[field.name]?.[nestedField.name]}
                                 />
-                                <ErrorMessage
-                                  name={`${field.name}.${nestedField.name}`}
-                                  component="div"
-                                  className="error"
-                                />{' '}
-                                {/* Display Formik error message */}
+                                <ErrorMessage name={`${field.name}.${nestedField.name}`} component="div" className="error" /> 
                               </Grid>
                             ));
-                          } else if (field.type === 'select') {
+                          } 
+                          // Handle select fields
+                          else if (field.type === 'select') {
                             return (
                               <Grid item xs={6} key={field.name}>
-                                <FormControl
-                                  fullWidth
-                                  error={
-                                    touched[field.name] &&
-                                    !!errors[field.name]
-                                  }
-                                >
-                                  <InputLabel id={`${field.name}-label`}>
-                                    {field.label}
-                                  </InputLabel>
+                                <FormControl fullWidth error={touched[field.name] && !!errors[field.name]}>
+                                  <InputLabel id={`${field.name}-label`}>{field.label}</InputLabel>
                                   <Field
                                     as={Select}
                                     labelId={`${field.name}-label`}
                                     id={field.name}
                                     name={field.name}
-                                    value={values[field.name] || ''}
+                                    value={values[field.name] || ''} 
                                   >
                                     {field.options.map((option) => (
-                                      <MenuItem
-                                        key={option.value}
-                                        value={option.value}
-                                      >
+                                      <MenuItem key={option.value} value={option.value}>
                                         {option.label}
                                       </MenuItem>
                                     ))}
                                   </Field>
-                                  <FormHelperText>
-                                    {touched[field.name] &&
-                                      errors[field.name]}
-                                  </FormHelperText>
+                                  <FormHelperText>{touched[field.name] && errors[field.name]}</FormHelperText>
                                 </FormControl>
                               </Grid>
                             );
-                          } else if (field.type === 'date') {
+                          } 
+                          // Handle date picker fields
+                          else if (field.type === 'date') {
                             return (
                               <Grid item xs={6} key={field.name}>
-                                <LocalizationProvider
-                                  dateAdapter={AdapterDayjs}
-                                >
+                                <LocalizationProvider dateAdapter={AdapterDayjs}>
                                   <DatePicker
                                     label={field.label}
                                     value={dayjs(values[field.name])}
-                                    onChange={(date) =>
-                                      setFieldValue(
-                                        field.name,
-                                        date.format('YYYY-MM-DD')
-                                      )
-                                    }
-                                    renderInput={(params) => (
-                                      <TextField
-                                        {...params}
-                                        fullWidth
-                                      />
-                                    )}
+                                    onChange={(date) => setFieldValue(field.name, date.format('YYYY-MM-DD'))}
+                                    renderInput={(params) => <TextField {...params} fullWidth />}
                                   />
                                 </LocalizationProvider>
                               </Grid>
                             );
-                          } else {
+                          } 
+                          // Default to TextField
+                          else {
                             return (
                               <Grid item xs={6} key={field.name}>
                                 <Field
@@ -236,34 +193,18 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                                   name={field.name}
                                   type={field.type || 'text'}
                                   fullWidth
-                                  error={
-                                    touched[field.name] &&
-                                    !!errors[field.name]
-                                  }
-                                  helperText={
-                                    touched[field.name] &&
-                                    errors[field.name]
-                                  }
+                                  error={touched[field.name] && !!errors[field.name]}
+                                  helperText={touched[field.name] && errors[field.name]}
                                 />
-                                <ErrorMessage
-                                  name={field.name}
-                                  component="div"
-                                  className="error"
-                                />{' '}
-                                {/* Display Formik error message */}
+                                <ErrorMessage name={field.name} component="div" className="error" />
                               </Grid>
                             );
                           }
                         })}
                       </Grid>
 
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          marginTop: 3,
-                        }}
-                      >
+                      {/* Button Controls */}
+                      <Box sx={{ display: 'flex', justifyContent: 'space-between', marginTop: 3 }}>
                         <Button
                           disabled={activeStep === 0}
                           onClick={handleBack}
@@ -272,14 +213,13 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                           Back
                         </Button>
 
-                        <Box> {/* Grouping the Cancel and Save buttons */}
+                        <Box>
                           <Button
-                            type="button"
+                            type="button" 
                             variant="outlined"
                             color="secondary"
-                            backgroundColor="grey"
-                            sx={{ marginRight: 2 }}
-                            onClick={onClose}
+                            sx={{ marginRight: 2, color: 'grey' }} 
+                            onClick={onClose} 
                           >
                             Cancel
                           </Button>
@@ -288,19 +228,9 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                             disabled={isSubmitting}
                             variant="contained"
                             color="primary"
-                            onClick={
-                              activeStep === steps.length - 1
-                                ? onSubmit
-                                : handleNext
-                            }
-                            sx={{
-                              backgroundColor:
-                                colors.greenAccent[600],
-                            }}
+                            sx={{ backgroundColor: colors.greenAccent[600] }}
                           >
-                            {activeStep === steps.length - 1
-                              ? 'Save Changes'
-                              : 'Next'}
+                            {activeStep === steps.length - 1 ? 'Save Changes' : 'Next'}
                           </Button>
                         </Box>
                       </Box>

--- a/src/components/Modals/AddModal.jsx
+++ b/src/components/Modals/AddModal.jsx
@@ -1,0 +1,215 @@
+// src/components/Modals/AddModal.jsx
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  Paper,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  CircularProgress,
+  Modal,
+} from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import { tokens } from "../../theme"; // Adjust this import as necessary
+
+const AddModal = ({ open, onClose, fields, onSubmit, title }) => {
+  const theme = useTheme();
+  const colors = tokens(theme.palette.mode);
+
+  const [formData, setFormData] = useState({});
+
+  useEffect(() => {
+    // Initialize formData based on the fields array 
+    const initialFormData = fields.reduce((data, field) => {
+      data[field.name] = field.initialValue || ''; // Use initialValue if provided, otherwise empty string
+      if (field.nestedFields) {
+        data[field.name] = field.nestedFields.reduce((nestedData, nestedField) => {
+          nestedData[nestedField.name] = nestedField.initialValue || '';
+          return nestedData;
+        }, {});
+      }
+      return data;
+    }, {});
+    setFormData(initialFormData);
+  }, [fields]); 
+
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    if (name.includes('.')) { 
+      const [parent, child] = name.split('.');
+      setFormData(prev => ({
+        ...prev,
+        [parent]: {
+          ...prev[parent],
+          [child]: value,
+        }
+      }));
+    } else {
+      setFormData(prev => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      await onSubmit(formData); // Call the onSubmit prop with the form data
+      setSuccess("Item created successfully. Click Cancel to close the form.");
+      setTimeout(() => {
+        setSuccess(null);
+      }, 3000); 
+    } catch (error) {
+      console.error("Error creating item:", error);
+      setError("An error occurred. Please try again."); 
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box sx={{ ...modalStyle, bgcolor: colors.primary[400] }}>
+        <Typography variant="h4" fontWeight="bold" mb={3} color={colors.grey[100]}>
+          {title} 
+        </Typography>
+        <Button
+          variant="outlined"
+          onClick={onClose} 
+          sx={{
+            mb: 2,
+            color: colors.grey[100],
+            borderColor: colors.grey[400],
+            "&:hover": {
+              borderColor: colors.grey[500],
+            },
+          }}
+        >
+          Cancel
+        </Button>
+        <Typography variant="body1" mb={2} color={colors.grey[100]}>
+          Fill in the form below to create a new item. 
+        </Typography>
+        {error && (
+          <Typography variant="body1" color="error" mb={2}>
+            {error}
+          </Typography>
+        )}
+        {success && (
+          <Typography variant="body1" color="success" mb={2}>
+            {success}
+          </Typography>
+        )}
+
+        <Paper elevation={3} sx={{ padding: 3, marginTop: 2, bgcolor: colors.primary[400] }}>
+          <form onSubmit={handleSubmit}>
+            <Grid container spacing={2}>
+              {fields.map((field) => (
+                <Grid item xs={12} sm={field.gridSize || 6} key={field.name}>
+                  {field.type === 'select' ? (
+                    <FormControl fullWidth variant="outlined" required={field.required}>
+                      <InputLabel id={`${field.name}-label`} sx={{ color: colors.grey[100] }}>{field.label}</InputLabel>
+                      <Select
+                        labelId={`${field.name}-label`}
+                        id={field.name}
+                        name={field.name}
+                        value={formData[field.name]} 
+                        onChange={handleChange}
+                        label={field.label}
+                        sx={{ 
+                          '.MuiOutlinedInput-notchedOutline': {
+                            borderColor: colors.grey[400],
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: colors.grey[500],
+                          },
+                          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                            borderColor: colors.greenAccent[700],
+                          },
+                          '.MuiSvgIcon-root': {
+                            color: colors.grey[400], 
+                          },
+                        }}
+                      >
+                        {field.options.map((option) => (
+                          <MenuItem key={option.value} value={option.value}>
+                            {option.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl> 
+                  ) : field.nestedFields ? (
+                    <Box>
+                      <Typography variant="h6" color={colors.grey[100]}>{field.label}</Typography> 
+                      <Grid container spacing={2}>
+                        {field.nestedFields.map((nestedField) => (
+                          <Grid item xs={12} sm={nestedField.gridSize || 6} key={nestedField.name}>
+                            <TextField
+                              fullWidth
+                              variant="outlined"
+                              label={nestedField.label}
+                              name={`${field.name}.${nestedField.name}`} 
+                              value={formData[field.name][nestedField.name]}
+                              onChange={handleChange}
+                              required={nestedField.required} 
+                            />
+                          </Grid>
+                        ))}
+                      </Grid>
+                    </Box>
+                  ) : ( 
+                    <TextField
+                      fullWidth
+                      variant="outlined"
+                      label={field.label}
+                      name={field.name}
+                      type={field.type || 'text'} 
+                      value={formData[field.name]}
+                      onChange={handleChange}
+                      required={field.required}
+                    />
+                  )}
+                </Grid>
+              ))}
+              <Grid item xs={12}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  sx={{
+                    backgroundColor: colors.greenAccent[600],
+                    color: 'white',
+                    '&:hover': { backgroundColor: colors.greenAccent[700] },
+                  }}
+                >
+                  {loading ? <CircularProgress size={24} color="inherit" /> : 'Create'}
+                </Button>
+              </Grid>
+            </Grid>
+          </form>
+        </Paper>
+      </Box>
+    </Modal>
+  );
+};
+
+const modalStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 700, 
+  bgcolor: 'background.paper',
+  boxShadow: 24,
+  p: 4,
+};
+
+export default AddModal;

--- a/src/components/Modals/ConfirmationDialog.jsx
+++ b/src/components/Modals/ConfirmationDialog.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Button from "@mui/material/Button";
+
+const ConfirmationDialog = ({ open, onClose, onConfirm, admin }) => (
+  <Dialog open={open} onClose={onClose}>
+    <DialogTitle>Warning</DialogTitle>
+    <DialogContent>
+      <DialogContentText>
+        Are you sure you want to delete {admin?.firstName} {admin?.lastName}?
+      </DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose} color="primary">
+        Cancel
+      </Button>
+      <Button onClick={onConfirm} color="primary">
+        Delete
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default ConfirmationDialog;

--- a/src/components/Modals/EditModal.jsx
+++ b/src/components/Modals/EditModal.jsx
@@ -74,7 +74,7 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
       } else if (field.type === 'date') {
         validator = Yup.date().typeError('Invalid date');
       } else {
-        validator = Yup.string(); 
+        validator = Yup.string();
       }
 
       if (field.required) {
@@ -97,7 +97,7 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
     {
       label: 'Next of Kin',
       description: 'Provide emergency contact information.',
-      fields: fields.filter((field) => field.name === 'nextOfKin'), 
+      fields: fields.filter((field) => field.name === 'nextOfKin'),
     },
   ];
 
@@ -113,12 +113,12 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
             <Step key={step.label}>
               <StepLabel>{step.label}</StepLabel>
               <StepContent>
-                <Typography>{step.description}</Typography> 
+                <Typography>{step.description}</Typography>
 
                 <Formik
                   initialValues={initialValues}
-                  validationSchema={validationSchema} 
-                  onSubmit={(values) => { 
+                  validationSchema={validationSchema}
+                  onSubmit={(values) => {
                     onSubmit(values);
                     setActiveStep(0); // Reset to the first step after submission 
                   }}
@@ -140,10 +140,10 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                                   error={touched[field.name]?.[nestedField.name] && !!errors[field.name]?.[nestedField.name]}
                                   helperText={touched[field.name]?.[nestedField.name] && errors[field.name]?.[nestedField.name]}
                                 />
-                                <ErrorMessage name={`${field.name}.${nestedField.name}`} component="div" className="error" /> 
+                                <ErrorMessage name={`${field.name}.${nestedField.name}`} component="div" className="error" />
                               </Grid>
                             ));
-                          } 
+                          }
                           // Handle select fields
                           else if (field.type === 'select') {
                             return (
@@ -155,7 +155,7 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                                     labelId={`${field.name}-label`}
                                     id={field.name}
                                     name={field.name}
-                                    value={values[field.name] || ''} 
+                                    value={values[field.name] || ''}
                                   >
                                     {field.options.map((option) => (
                                       <MenuItem key={option.value} value={option.value}>
@@ -167,7 +167,7 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                                 </FormControl>
                               </Grid>
                             );
-                          } 
+                          }
                           // Handle date picker fields
                           else if (field.type === 'date') {
                             return (
@@ -182,7 +182,7 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
                                 </LocalizationProvider>
                               </Grid>
                             );
-                          } 
+                          }
                           // Default to TextField
                           else {
                             return (
@@ -215,11 +215,11 @@ const EditModal = ({ open, onClose, initialValues, onSubmit, fields }) => {
 
                         <Box>
                           <Button
-                            type="button" 
+                            type="button"
                             variant="outlined"
                             color="secondary"
-                            sx={{ marginRight: 2, color: 'grey' }} 
-                            onClick={onClose} 
+                            sx={{ marginRight: 2, color: 'grey' }}
+                            onClick={onClose}
                           >
                             Cancel
                           </Button>

--- a/src/components/Modals/ViewModal.jsx
+++ b/src/components/Modals/ViewModal.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { 
+import {
   Modal, Box, Typography, Divider, Grid, Avatar, Button, IconButton, Chip
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { tokens } from '../theme';
+import { tokens } from '../../theme';
 import CloseIcon from '@mui/icons-material/Close';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -17,7 +17,7 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    width: 700,
+    width: 500,
     bgcolor: 'background.paper',
     boxShadow: 24,
     p: 4,
@@ -27,11 +27,11 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
     <Modal open={open} onClose={onClose}>
       <Box sx={style}>
         {recordData && (
-          <Box sx={{ position: 'relative' }}> 
+          <Box sx={{ position: 'relative' }}>
             {/* Close Button */}
-            <IconButton 
-              aria-label="close" 
-              onClick={onClose} 
+            <IconButton
+              aria-label="close"
+              onClick={onClose}
               sx={{ position: 'absolute', top: 8, right: 8 }}
             >
               <CloseIcon />
@@ -39,11 +39,11 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
 
             <Grid container spacing={2} alignItems="center">
               {/* Profile Image */}
-              <Grid item xs={12} textAlign="center" mb={2}> 
-                <Avatar 
-                  alt="Profile" 
-                  src={recordData.profileImage} 
-                  sx={{ width: 150, height: 150, margin: 'auto' }} 
+              <Grid item xs={12} textAlign="center" mb={2}>
+                <Avatar
+                  alt="Profile"
+                  src={recordData.profileImage}
+                  sx={{ width: 150, height: 150, margin: 'auto' }}
                 />
               </Grid>
 
@@ -52,14 +52,14 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
                 <Typography variant="h4" fontWeight="bold" mb={1}>
                   {recordData.firstName} {recordData.lastName}
                 </Typography>
-                <Chip 
-                  label={recordData.role} 
-                  color="primary" 
+                <Chip
+                  label={recordData.role}
+                  color="primary"
                   size="medium"
                   sx={{ fontWeight: 'bold' }}
                 />
-                <Chip 
-                  label={recordData.staffId} 
+                <Chip
+                  label={recordData.staffId}
                   size="small"
                   sx={{ fontWeight: 'bold', backgroundColor: colors.greenAccent[500], color: colors.grey[100] }}
                 />
@@ -67,7 +67,7 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
 
               {/* Standard Fields (2-Column Layout) */}
               {fields
-                .filter((field) => !field.nestedFields && field.name !== 'profileImage') 
+                .filter((field) => !field.nestedFields && field.name !== 'profileImage')
                 .map((field) => (
                   <Grid item xs={6} key={field.name}>
                     <Typography sx={{ mt: 1 }}>
@@ -78,7 +78,7 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
 
               {/* Next of Kin Section */}
               {recordData.nextOfKin && (
-                <Grid item xs={12} mt={3}> 
+                <Grid item xs={12} mt={3}>
                   <Typography variant="h6" color={colors.greenAccent[500]}>
                     Next of Kin
                   </Typography>
@@ -95,23 +95,23 @@ const ViewModal = ({ open, onClose, recordData, fields }) => {
 
               {/* Buttons (Full Width) */}
               <Grid item xs={12} mt={4} display="flex" justifyContent="center">
-                <Button 
-                  variant="contained" 
-                  sx={{ 
+                <Button
+                  variant="contained"
+                  sx={{
                     backgroundColor: colors.greenAccent[600],
                     color: colors.grey[100],
-                    '&:hover': { backgroundColor: colors.greenAccent[700] } 
+                    '&:hover': { backgroundColor: colors.greenAccent[700] }
                   }}
                   onClick={onClose}
                 >
-                  Return to Dashboard 
+                  Return to Dashboard
                 </Button>
 
                 <IconButton aria-label="edit" sx={{ ml: 2, color: colors.greenAccent[600] }}>
                   <EditIcon />
                 </IconButton>
 
-                <IconButton aria-label="delete" sx={{ ml: 2, color: 'red' }}> 
+                <IconButton aria-label="delete" sx={{ ml: 2, color: 'red' }}>
                   <DeleteIcon />
                 </IconButton>
               </Grid>

--- a/src/scenes/team/index.jsx
+++ b/src/scenes/team/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext, useCallback, useMemo } from 'react';
 import {
-  Box, Avatar, Typography, Button, ButtonGroup, Grid, Menu, MenuItem, Link, Modal, InputBase, InputAdornment, IconButton
+  Box, Chip, Avatar, Typography, Button, Grid, Menu, MenuItem, Link, InputBase, InputAdornment, IconButton
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
@@ -10,10 +10,15 @@ import { useTheme } from '@mui/material/styles';
 import { tokens } from '../../theme';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import AuthContext from '../../context/AuthContext';
-import ViewModal from '../../components/ViewModal';
-import EditModal from '../../components/EditModal';
+import ViewModal from '../../components/Modals/ViewModal';
+import EditModal from '../../components/Modals/EditModal';
 import { teamViewFields } from './teamFields';
 import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined';
+import ConfirmationDialog from './ConfirmationDialog';
+import AddModal from '../../components/Modals/AddModal'; // Update the import path
+
+
+
 
 const TeamManager = () => {
   // Fetch admin data from the server
@@ -45,7 +50,7 @@ const TeamManager = () => {
 
   useEffect(() => {
     fetchAdmins();
-  }, []);
+  }, [fetchAdmins]);
 
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
@@ -57,7 +62,6 @@ const TeamManager = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [searchText, setSearchText] = useState('');
   const [anchorEl, setAnchorEl] = useState(null);
-  const [openMenuId, setOpenMenuId] = useState(null);
 
   // Memoize filteredRows for performance
   const filteredRows = useMemo(() => {
@@ -73,14 +77,13 @@ const TeamManager = () => {
     });
   }, [adminData, searchText]);
 
-  const handleClick = (event, row) => { // Update handleClick to accept row data
+  const handleClick = (event, row) => {
     setAnchorEl(event.currentTarget);
-    setSelectedAdmin(row); // Set the selected admin when clicking the dropdown
+    setSelectedAdmin(row);
   };
 
   const handleClose = () => {
     setAnchorEl(null);
-    setOpenMenuId(null);
   };
 
   const handleView = (admin) => {
@@ -97,14 +100,64 @@ const TeamManager = () => {
     setEditAdminData(admin);
     setOpenEditModal(true);
   };
+  // Delete an admin (using ConfirmationDialog)
+  const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
+  const [adminToDelete, setAdminToDelete] = useState(null);
+
+  const handleDelete = async (admin) => {
+    try {
+      const response = await fetch(`${apiUrl}/admin/admin-delete/${admin._id}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        setAdminData(prevData => prevData.filter(item => item._id !== admin._id));
+        alert('Success', 'Admin deleted successfully!');
+      } else {
+        const errorData = await response.json();
+        alert('Error', errorData.message || 'Failed to delete the admin.');
+      }
+    } catch (error) {
+      alert('Error', 'Failed to delete the admin.');
+    }
+  };
+
+  // Combine handleDelete and confirmDelete into a single function 
+  const handleConfirmDelete = async () => {
+    try {
+      const response = await fetch(`${apiUrl}/admin/admin-delete/${adminToDelete._id}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        setAdminData(prevData => prevData.filter(item => item._id !== adminToDelete._id));
+        alert('Success', 'Admin deleted successfully!');
+      } else {
+        const errorData = await response.json();
+        alert('Error', errorData.message || 'Failed to delete the admin.');
+      }
+    } catch (error) {
+      alert('Error', 'Failed to delete the admin.');
+    } finally {
+      setOpenConfirmDialog(false);
+      setAdminToDelete(null);
+    }
+  };
 
   const handleEditSubmit = async (values) => {
     console.log('Updating admin with values:', values);
 
     try {
-      // 1. Make API call to update the admin data
       const response = await fetch(`${apiUrl}/admin/admin-update/${values._id}`, {
-        method: 'PUT', // Or PATCH, depending on your API
+        method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
@@ -116,7 +169,6 @@ const TeamManager = () => {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
 
-      // 2. Update the adminData state (after successful API call)
       const updatedAdminData = await response.json();
       setAdminData(prevData =>
         prevData.map(admin => (admin._id === updatedAdminData._id ? updatedAdminData : admin))
@@ -125,23 +177,72 @@ const TeamManager = () => {
       setOpenEditModal(false);
     } catch (error) {
       console.error('Error updating admin:', error);
-      // Handle error (display error message, etc.)
+    }
+  };
+  const [openAddModal, setOpenAddModal] = useState(false);
+
+  const handleOpenAddModal = () => {
+    setOpenAddModal(true);
+  };
+
+  const handleCloseAddModal = () => {
+    setOpenAddModal(false);
+  };
+
+  const handleSubmitNewAdmin = async (formData) => {
+    try {
+      const response = await fetch(`${apiUrl}/admin/admin-create`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(formData),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create admin');
+      }
+
+      const newAdmin = await response.json();
+      setAdminData(prevData => [...prevData, newAdmin]); // Update adminData
+      handleCloseAddModal();
+    } catch (error) {
+      console.error("Error creating admin:", error);
+      // Handle error (e.g., display an error message)
     }
   };
 
   const columns = [
     {
-      field: 'profileImage', // Add the image field
-      headerName: 'Profile',
+      field: 'profileImage',
+      headerName: 'Avatar',
       width: 80,
       renderCell: (params) => (
-        <Avatar alt={params.row.firstName} src={params.row.profileImage} /> // Display the image in the Avatar
+        <Avatar alt={params.row.firstName} src={params.row.profileImage} />
       ),
     },
-    { field: "staffId", headerName: "Staff ID", width: 130 },
-    { field: "firstName", headerName: "Firstname", flex: 1 },
-    { field: "lastName", headerName: "Surname", flex: 1 },
-    { field: "emailAddress", headerName: "Email", flex: 1 },
+    {
+      field: 'nameAndId', // Combine name and staffId
+      headerName: 'Full Name - Staff ID',
+      flex: 2,
+      renderCell: (params) => (
+        <Box display="flex" alignItems="center">
+          <Typography variant="h6" sx={{ fontWeight: 'bold', marginRight: '8px', }}>
+            {`${params.row.firstName} ${params.row.lastName}`}
+          </Typography>
+          <Chip
+            label={`${params.row.staffId}`}
+            sx={{
+              backgroundColor: colors.greenAccent[500],
+              color: colors.primary.contrastText,
+              padding: '41px 8px',
+            }}
+          />
+        </Box>
+      ),
+    },
+    { field: "emailAddress", headerName: "Email", flex: 2 },
     { field: "phoneNumber", headerName: "Phone Number", flex: 1 },
     { field: "city", headerName: "Location", flex: 1 },
     { field: "role", headerName: "Role", flex: 1 },
@@ -171,10 +272,9 @@ const TeamManager = () => {
           >
             <ArrowDropDownIcon />
           </IconButton>
-          {/* Menu should be outside the ButtonGroup */}
           <Menu
             anchorEl={anchorEl}
-            open={Boolean(anchorEl)} // Open menu when anchorEl is set
+            open={Boolean(anchorEl)}
             onClose={handleClose}
           >
             <MenuItem onClick={() => { handleEdit(selectedAdmin); handleClose(); }}>Edit</MenuItem>
@@ -226,6 +326,7 @@ const TeamManager = () => {
                 </InputAdornment>
               }
             />
+            {/* Add Team Button */}
             <Button
               sx={{
                 backgroundColor: colors.greenAccent[600],
@@ -236,9 +337,10 @@ const TeamManager = () => {
                 marginRight: isMobile ? "0" : "0px",
                 marginBottom: isMobile ? "10px" : "0",
                 '&:hover': {
-                  backgroundColor: colors.greenAccent[600], // Darker green on hover
+                  backgroundColor: colors.greenAccent[600],
                 },
               }}
+              onClick={handleOpenAddModal}
             >
               <PersonAddOutlinedIcon sx={{ mr: "10px" }} />
               Add Team
@@ -283,6 +385,10 @@ const TeamManager = () => {
                 getRowId={(row) => row._id}
                 columns={columns}
                 pageSize={10}
+                onRowClick={(params) => {
+                  const clickedAdmin = params.row;
+                  handleView(clickedAdmin);
+                }}
                 rowsPerPageOptions={[10, 25, 50, 100]}
               />
             )}
@@ -305,11 +411,21 @@ const TeamManager = () => {
           onSubmit={handleEditSubmit}
           fields={teamViewFields}
         />
-
-        {/* ConfirmationDialog (You'll need to implement this from your Prof's code) */}
-        {/* <ConfirmationDialog 
-          // ... props for the ConfirmationDialog 
-        /> */}
+        {/* AddModal */}
+        <AddModal
+          open={openAddModal}
+          onClose={handleCloseAddModal}
+          fields={teamViewFields}
+          onSubmit={handleSubmitNewAdmin}
+          title="Create New Admin"
+        />
+        {/* ConfirmationDialog */}
+        <ConfirmationDialog
+          open={openConfirmDialog}
+          onClose={() => setOpenConfirmDialog(false)}
+          onConfirm={handleConfirmDelete}  // Use handleConfirmDelete here
+          admin={adminToDelete}
+        />
       </Grid>
     </Box>
   );

--- a/src/scenes/team/index.jsx
+++ b/src/scenes/team/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useCallback } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import {
   Box,
   Typography,
@@ -9,7 +9,6 @@ import {
   Menu,
   MenuItem,
   Link,
-  Avatar
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -24,34 +23,34 @@ import EditAdmin from "./EditAdmin";
 import AuthContext from "../../context/AuthContext";
 
 const TeamManager = () => {
+  // Fetch admin data from the server
   const apiUrl = process.env.REACT_APP_API_URL;
   const { token } = useContext(AuthContext);
 
   const [adminData, setAdminData] = useState(null);
-  const fetchAdmins = useCallback(async () => {
-    try {
-      const response = await fetch(`${apiUrl}/admin/admin-get-all`, { // Closing bracket added here
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }); 
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
-      }
-      const data = await response.json();
-      if (data) {
-        setAdminData(data.admins);
-      } else {
-        setAdminData([]);
-      }
-    } catch (error) {
-      console.error('Error fetching admins:', error);
-    }
-  }, [apiUrl, token]); 
-
+   const fetchAdmins = async () => {
+     try {
+       const response = await fetch(`${apiUrl}/admin/admin-get-all`, {
+          headers: {
+           Authorization: `Bearer ${token}`,
+          },
+       });
+       if (!response.ok) {
+         throw new Error("Network response was not ok");
+       }
+       const data = await response.json();
+       if (data) {
+         setAdminData(data.admins);
+       } else {
+         setAdminData([]);
+       }
+     } catch (error) {
+       console.error("Error fetching admins:", error);
+     }
+   };
   useEffect(() => {
     fetchAdmins();
-  }, [fetchAdmins]);
+  }, []);
 
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
@@ -154,23 +153,9 @@ const TeamManager = () => {
     { field: "phoneNumber", headerName: "Phone Number", flex: 1 },
     { field: "city", headerName: "Location", flex: 1 },
     { field: "role", headerName: "Role", flex: 1 },
-    { field: 'staffId', headerName: 'Staff ID', width: 100 },
     {
-      field: 'profileImage',
-      headerName: 'Profile',
-      width: 80,
-      renderCell: (params) => (
-        <Avatar alt={params.row.name} src={params.row.profileImage} />
-      ),
-    },
-    { field: 'name', headerName: 'Name', flex: 2 },
-    { field: 'email', headerName: 'Email', flex: 1 },
-    { field: 'phone', headerName: 'Phone Number', flex: 1 },
-    { field: 'location', headerName: 'Location', flex: 1 },
-    { field: 'role', headerName: 'Role', flex: 1 },
-    {
-      field: 'actions',
-      headerName: 'Actions',
+      field: "actions",
+      headerName: "Actions",
       width: 200,
       renderCell: (params) => (
         <ButtonGroup variant="contained">
@@ -216,7 +201,7 @@ const TeamManager = () => {
     if (!openCreateAdmin && !openEditAdmin) {
       fetchAdmins();
     }
-  }, [openCreateAdmin, openEditAdmin, fetchAdmins]);
+  }, [openCreateAdmin, openEditAdmin]);
 
 
   return (


### PR DESCRIPTION

This commit implements the Team Management section of the admin dashboard, 
fetching data from the API and integrating reusable modal components for 
viewing, editing, and deleting admins. 

Key changes:

- Created a reusable AddModal component (src/components/Modals/AddModal.jsx) 
  for creating new admins and potentially other entities in the future.
- Updated TeamManager.jsx to:
  - Fetch admin data from the API using the useAdmins custom hook.
  - Integrate the AddModal for creating new admins.
  - Replace the old admin details view with the reusable ViewModal.
  - Use the reusable EditModal for editing admin details. 
  - Implement delete functionality using the ConfirmationDialog.
- Improved the DataGrid by:
  - Adding an Avatar column to display profile images.
  - Styling the Full Name column as a Chip with the Staff ID. 
  - Using useMemo to memoize the filteredRows and columns for better performance. 

This commit significantly improves the organization, maintainability, and 
functionality of the Team Management section. 